### PR TITLE
conda build for SMESH

### DIFF
--- a/pkg/conda/build.sh
+++ b/pkg/conda/build.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+
+# GFORTRAN AND LIBQUADMATH ARE LOCAL LIBRARIES!!!
+
+
+set -e
+
+ncpus=4
+
+echo "Timestamp" && date
+mkdir cmake-build
+cd cmake-build
+cmake -DOCE_INCLUDE_PATH=$PREFIX/include/oce \
+      -DCMAKE_BUILD_TYPE:STRING=Release \
+      -DOCE_LIB_PATH=$PREFIX/lib \
+      -DOCE_INSTALL_PACKAGE_LIB_DIR=$PREFIX/lib \
+      -DSMESH_INSTALL_PREFIX=$PREFIX \
+      ..
+echo ""
+echo "Timestamp" && date
+# make for py3
+echo "Starting build with -j$ncpus ..."
+# travis-ci truncates when there are more than 10,000 lines of output.
+# trim them to see test results.
+make -j$ncpus install | grep Built
+# Run tests
+echo "Timestamp" && date

--- a/pkg/conda/meta.yaml
+++ b/pkg/conda/meta.yaml
@@ -1,0 +1,26 @@
+package:
+  name: smesh # lower case name of package, may contain '-' but no spaces
+  version: "5.1.2" # version of package. Should use the PEP-386 verlib
+
+source:
+  git_url: https://github.com/tpaviot/smesh.git
+
+build:
+  # The build number should be incremented for new builds of the same version
+  number: 1     # (defaults to 0)
+  binary_relocation: true # (defaults to true)
+
+requirements:
+  build:
+    - gcc # gfortran
+    - opencascade_community_edition
+
+#  # Packages required to run the package. These are the dependencies that
+#  # will be installed automatically whenever the package is installed.
+  run:
+    - opencascade_community_edition
+
+about:
+  home: https://github.com/tpaviot/smesh
+  summary: finite element generation for OpenCasCADE
+  license: LGPL


### PR DESCRIPTION
conda build for SMESH

libquadmath and libgfortan are linked to using @loader_path
in other words, this binary is relocatable and does not rely on any other libs ( like gcc for gfortran ) being installed
