### PR TITLE
[cppcheck-warning-fix][unititialized-variable]

### DIFF
--- a/src/SMESH/SMESH_MeshEditor.cpp
+++ b/src/SMESH/SMESH_MeshEditor.cpp
@@ -5222,7 +5222,7 @@ void SMESH_MeshEditor::MergeNodes (TListOfListOfNodes & theGroupsOfNodes)
             // --------------------------------------------> 2 tetrahedrons
             const int *ind1 = hexa.GetFaceNodesIndices( iQuadFace[ 0 ]); // indices of quad1 nodes
             const int *ind2 = hexa.GetFaceNodesIndices( iQuadFace[ 1 ]);
-            int i0, i1d, i2, i3d, i0t, i2t; // d-daigonal, t-top
+            int i0=0, i1d=0, i2=0, i3d=0, i0t=0, i2t=0; // d-daigonal, t-top
             if (curNodes[ind1[ 0 ]] == curNodes[ind2[ 0 ]] &&
                 curNodes[ind1[ 2 ]] == curNodes[ind2[ 2 ]]) {
               // stuck with 0-2 diagonal

--- a/src/SMESH/SMESH_Pattern.cpp
+++ b/src/SMESH/SMESH_Pattern.cpp
@@ -925,7 +925,7 @@ bool SMESH_Pattern::Load (SMESH_Mesh*        theMesh,
       // mesh is projected onto a line, e.g.
       return setErrorCode( ERR_LOADF_CANT_PROJECT );
   }
-  double ratio = dU / dV, maxratio = 3, scale;
+  double ratio = dU / dV, maxratio = 3, scale=0.;
   int iCoord = 0;
   if ( ratio > maxratio ) {
     scale = ratio / maxratio;


### PR DESCRIPTION
This commit fixes following cppcheck-1.67 issues:
[/src/SMESH/SMESH_MeshEditor.cpp:5250]: (error) Uninitialized variable: i0
[/src/SMESH/SMESH_MeshEditor.cpp:5251]: (error) Uninitialized variable: i1d
[/src/SMESH/SMESH_MeshEditor.cpp:5256]: (error) Uninitialized variable: i1d
[/src/SMESH/SMESH_MeshEditor.cpp:5257]: (error) Uninitialized variable: i2
[/src/SMESH/SMESH_MeshEditor.cpp:5252]: (error) Uninitialized variable: i3d
[//src/SMESH/SMESH_MeshEditor.cpp:5258]: (error) Uninitialized variable: i3d
[/src/SMESH/SMESH_MeshEditor.cpp:5253]: (error) Uninitialized variable: i0t
[/src/SMESH/SMESH_MeshEditor.cpp:5259]: (error) Uninitialized variable: i2t
[/src/SMESH/SMESH_Pattern.cpp:939]: (error) Uninitialized variable: scale
