### PR TITLE
Fix building with clang 7.1.0

### DIFF
--- a/src/SMESH/SMESH_MeshEditor.cpp
+++ b/src/SMESH/SMESH_MeshEditor.cpp
@@ -6965,7 +6965,7 @@ SMESH_MeshEditor::SewFreeBorder (const SMDS_MeshNode* theBordFirstNode,
   // sew the border to the side 2
   // ============================
 
-  int nbNodes[]  = { nSide[0].size(), nSide[1].size() };
+  int nbNodes[]  = { static_cast<int>(nSide[0].size()), static_cast<int>(nSide[1].size()) };
   int maxNbNodes = Max( nbNodes[0], nbNodes[1] );
 
   TListOfListOfNodes nodeGroupsToMerge;


### PR DESCRIPTION
Converting the (unsigned long) size to int is not allowed
when building with strict narrowing on clang (`-Wc++11-narrowing`)